### PR TITLE
Fix page tree and video availability checks

### DIFF
--- a/Classes/Domain/Repository/FileRepository.php
+++ b/Classes/Domain/Repository/FileRepository.php
@@ -317,7 +317,7 @@ class FileRepository
                 )
             )
             ->executeQuery();
-        $rows = $result->fetchAssociative();
+        $rows = $result->fetchAllAssociative();
 
         $pageIds = [];
         foreach ($rows as $row) {

--- a/Classes/Service/Validator/AbstractVideoValidator.php
+++ b/Classes/Service/Validator/AbstractVideoValidator.php
@@ -18,6 +18,6 @@ abstract class AbstractVideoValidator implements AbstractVideoValidatorInterface
             $this->getOEmbedUrl($mediaId)
         );
 
-        return is_string($oEmbed) ?? false;
+        return is_string($oEmbed);
     }
 }


### PR DESCRIPTION
## Summary
- fix fetching multiple page IDs in `FileRepository`
- simplify `isVideoOnline()` logic

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841cb4504e483298e71a1bfc75a4b4d